### PR TITLE
Modif "Historiques" côté serveur

### DIFF
--- a/2017/SimBourse/src/core/Marche.java
+++ b/2017/SimBourse/src/core/Marche.java
@@ -25,7 +25,7 @@ public class Marche {
 	private Map<Action, Set<Ordre>> liste_ventes;
 	private List<Joueur> liste_joueurs;
 	private Set<Integer> liste_id_ordres;
-	private Map<Action, Set<Echange>> historiques,histoPartiel;
+	private Map<Action, Set<Echange>> historiques;
 	private final Lock mutex = new ReentrantLock();
 	private Thread timer = null;
 

--- a/2017/SimBourse/src/core/Marche.java
+++ b/2017/SimBourse/src/core/Marche.java
@@ -1,8 +1,10 @@
 package core;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -13,6 +15,8 @@ import java.util.concurrent.locks.ReentrantLock;
 
 import org.apache.commons.lang3.tuple.Pair;
 
+
+
 public class Marche {
 	private boolean ouvert;
 	private boolean fini;
@@ -21,7 +25,7 @@ public class Marche {
 	private Map<Action, Set<Ordre>> liste_ventes;
 	private List<Joueur> liste_joueurs;
 	private Set<Integer> liste_id_ordres;
-	private Map<Action, Set<Echange>> historiques;
+	private Map<Action, Set<Echange>> historiques,histoPartiel;
 	private final Lock mutex = new ReentrantLock();
 	private Thread timer = null;
 
@@ -115,8 +119,17 @@ public class Marche {
 		return liste_ventes.get(a);
 	}
 
-	public Set<Echange> getHistoriqueEchanges(Action a) {
-		return historiques.get(a);
+	public Set<Echange> getHistoriqueEchanges(Action a,int n) {
+		List<Echange> list = new ArrayList<>();
+		final Iterator<Echange> i = historiques.get(a).iterator();
+		for(int j=0;j<n;j++)
+			i.next();
+		for (int j=n; j<historiques.get(a).size() && i.hasNext();j++)
+			list.add(i.next());
+		//historiques.get(a)
+		Set<Echange> retour= new LinkedHashSet<>(list);
+		
+		return retour;
 	}
 
 	public int achat(Joueur joueur_achat, Action a, float prix_achat, int volume_achat) {

--- a/2017/SimBourse/src/network/Client.java
+++ b/2017/SimBourse/src/network/Client.java
@@ -48,7 +48,7 @@ public class Client extends Thread {
 				String[] arguments = userInput.split(" ");
 				boolean peut_jouer = (create || join) && current.getMarche().est_ouvert() && !current.getMarche().est_fini();
 
-				// Utilisateur n'ayant ni crÃ©Ã© ni rejoint peut crÃ©er
+				// Utilisateur n'ayant ni créé ni rejoint peut créer
 				if (userInput.startsWith("CREATE ") && arguments.length == 2 && !create && !join) {
 					String nom = arguments[1];
 					numero_partie = (int) (Math.random() * 100000);

--- a/2017/SimBourse/src/network/Client.java
+++ b/2017/SimBourse/src/network/Client.java
@@ -30,7 +30,7 @@ public class Client extends Thread {
 	}
 
 	public void run() {
-		System.out.println("Client connectÃ©");
+		System.out.println("Client connecté");
 
 		Partie current = null;
 		Joueur joueur = null;
@@ -177,7 +177,7 @@ public class Client extends Thread {
 		} else if (!create) {
 			client.close();
 		}
-		System.out.println("Client dÃ©connectÃ©");
+		System.out.println("Client déconnecté");
 	}
 
 	private <E, V> String MapToStringPython(Map<E, V> map) {

--- a/2017/SimBourse/src/network/Client.java
+++ b/2017/SimBourse/src/network/Client.java
@@ -30,7 +30,7 @@ public class Client extends Thread {
 	}
 
 	public void run() {
-		System.out.println("Client connecté");
+		System.out.println("Client connectÃ©");
 
 		Partie current = null;
 		Joueur joueur = null;
@@ -48,7 +48,7 @@ public class Client extends Thread {
 				String[] arguments = userInput.split(" ");
 				boolean peut_jouer = (create || join) && current.getMarche().est_ouvert() && !current.getMarche().est_fini();
 
-				// Utilisateur n'ayant ni créé ni rejoint peut créer
+				// Utilisateur n'ayant ni crÃ©Ã© ni rejoint peut crÃ©er
 				if (userInput.startsWith("CREATE ") && arguments.length == 2 && !create && !join) {
 					String nom = arguments[1];
 					numero_partie = (int) (Math.random() * 100000);
@@ -102,10 +102,10 @@ public class Client extends Thread {
 				} else if (userInput.startsWith("VENTES ") && arguments.length == 2 && Action.estValide(arguments[1]) && peut_jouer) {
 					Action a = Action.from(arguments[1]);
 					envoyer(out, String.valueOf(current.getMarche().getListeVentes(a)));
-				} else if (userInput.startsWith("HISTO ") && arguments.length == 2 && Action.estValide(arguments[1]) && 
+				} else if (userInput.startsWith("HISTO ") && arguments.length == 3 && Action.estValide(arguments[1]) && 
 						(create || join) && current.getMarche().est_ouvert()) {
 					Action a = Action.from(arguments[1]);
-					envoyer(out, String.valueOf(current.getMarche().getHistoriqueEchanges(a)));
+					envoyer(out, String.valueOf(current.getMarche().getHistoriqueEchanges(a,Integer.parseInt(arguments[2]))));
 				} else if (userInput.startsWith("ASK ") && arguments.length == 4 && Action.estValide(arguments[1])
 						&& NumberUtils.isCreatable(arguments[2]) && StringUtils.isNumeric(arguments[3]) && peut_jouer) {
 					Action a = Action.from(arguments[1]);
@@ -177,7 +177,7 @@ public class Client extends Thread {
 		} else if (!create) {
 			client.close();
 		}
-		System.out.println("Client déconnecté");
+		System.out.println("Client dÃ©connectÃ©");
 	}
 
 	private <E, V> String MapToStringPython(Map<E, V> map) {
@@ -209,3 +209,4 @@ public class Client extends Thread {
 		return new String(sb);
 	}
 }
+

--- a/2017/SimBourse/src/network/Client.java
+++ b/2017/SimBourse/src/network/Client.java
@@ -102,8 +102,8 @@ public class Client extends Thread {
 				} else if (userInput.startsWith("VENTES ") && arguments.length == 2 && Action.estValide(arguments[1]) && peut_jouer) {
 					Action a = Action.from(arguments[1]);
 					envoyer(out, String.valueOf(current.getMarche().getListeVentes(a)));
-				} else if (userInput.startsWith("HISTO ") && arguments.length == 3 && Action.estValide(arguments[1]) && 
-						(create || join) && current.getMarche().est_ouvert()) {
+				} else if (userInput.startsWith("HISTO ") && arguments.length == 3 && Action.estValide(arguments[1]) &&
+						StringUtils.isNumeric(arguments[2]) && (create || join) && current.getMarche().est_ouvert()) {
 					Action a = Action.from(arguments[1]);
 					envoyer(out, String.valueOf(current.getMarche().getHistoriqueEchanges(a,Integer.parseInt(arguments[2]))));
 				} else if (userInput.startsWith("ASK ") && arguments.length == 4 && Action.estValide(arguments[1])
@@ -209,4 +209,3 @@ public class Client extends Thread {
 		return new String(sb);
 	}
 }
-

--- a/2017/client.py
+++ b/2017/client.py
@@ -42,7 +42,7 @@ class Reseau:
 	def __init__(self, host="matthieu-zimmer.net", port=23456):
 		self.connect = False
 		self.topbool = False
-		self.histoActions={"Facebook":[],"Google":[],"Trydea":[],"Apple":[]}
+		self.histoActions={}
 		self.tempsFinPartie= 0
 		self.sock=socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 		self.sock.settimeout(5)
@@ -132,8 +132,13 @@ class Reseau:
 		self.__envoyer("TOP")
 		r = int(self.__recevoir())
 		self.topbool= True
+		
 		self.__envoyer("FIN") #Pour avoir la duree de la partie
 		self.tempsFinPartie=time.time() + int(eval(self.__recevoir())['temps']) #lance le 'chronometre' quand le serveur a lance le top
+		for key in self.solde():
+			if key!='euros':
+				self.histoActions[key]=[] #on ajoute les différentes actions dans le tableau historique du client
+		
 		return r
 
 	def solde(self):

--- a/2017/client.py
+++ b/2017/client.py
@@ -42,8 +42,8 @@ class Reseau:
 	def __init__(self, host="matthieu-zimmer.net", port=23456):
 		self.connect = False
 		self.topbool = False
-		self.timerInitial = 0
-		self.tempsPartie= 0
+		self.histoActions={"Facebook":[],"Google":[],"Trydea":[],"Apple":[]}
+		self.tempsFinPartie= 0
 		self.sock=socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 		self.sock.settimeout(5)
 		result = self.sock.connect_ex((host, port))
@@ -133,8 +133,7 @@ class Reseau:
 		r = int(self.__recevoir())
 		self.topbool= True
 		self.__envoyer("FIN") #Pour avoir la duree de la partie
-		self.tempsPartie=int(eval(self.__recevoir())['temps'])
-		self.timerInitial=time.time() #lance le 'chronometre' quand le serveur a lance le top
+		self.tempsFinPartie=time.time() + int(eval(self.__recevoir())['temps']) #lance le 'chronometre' quand le serveur a lance le top
 		return r
 
 	def solde(self):
@@ -241,8 +240,10 @@ class Reseau:
 		'''
 		self.__estTop()
 		self.__notEnd()
-		self.__envoyer("HISTO "+action)
-		return eval(self.__recevoir())
+		self.__envoyer("HISTO "+action+" "+str(len(self.histoActions[action])))
+		self.histoActions[action]+=(eval(self.__recevoir()))
+		return self.histoActions[action]
+		#return eval(self.__recevoir())
 
 	def suivreOperation(self, id_ordre):
 		'''
@@ -286,7 +287,7 @@ class Reseau:
 
 			
 		self.__estTop()
-		tempsRestant=self.tempsPartie + self.timerInitial - time.time() #tempsPartie-(TempsAct-TempsInitial)
+		tempsRestant=self.tempsFinPartie - time.time() #fin de partie - maintenant
 		if(tempsRestant>0): #Dans ce cas, pas besoin de faire une requête au serveur, on affiche simplement le temps restant
 			return {'temps': int(tempsRestant)+1}
 		#si la partie est finie on fait une requete au serveur pour qu'il donne la liste des vainqueurs

--- a/README.md
+++ b/README.md
@@ -5,11 +5,15 @@ Documentation officielle : https://matthieu637.github.io/cpp-2a-info/client.Rese
 
 [Documentation alternative (non vérifiée)](http://documentation-matthieu-devalle.readthedocs.io) par [MatthieuDEVALLE](https://github.com/matthieuDEVALLE)
 
-### Contributions
+### Contributions (la suite ne concernent que les personnes voulant aller plus loin avant la compétition)
 Pour les plus motiver, nous vous encourageons à améliorer le projet (il vous faudra un compte sur github, utiliser [git](https://openclassrooms.com/courses/gerer-son-code-avec-git-et-github), [forker le projet et proposer des pull requests](https://help.github.com/articles/creating-a-pull-request-from-a-fork/)).
 
 Attention à garder vos [branches à jour](https://help.github.com/articles/syncing-a-fork/#platform-linux)
-avant de pull request au risque que nos branches master divergent (https://github.com/matthieu637/cpp-2a-info/network). Cela vous permettra également de résoudre les conflits avant tout pull request.
+avant de pull request au risque que nos branches master divergent (https://github.com/matthieu637/cpp-2a-info/network). Cela vous permettra également de résoudre les conflits avant tout pull request :
+```
+git remote add upstream https://github.com/matthieu637/cpp-2a-info.git
+git pull upstream master
+```
 
 Pour reporter des bugs, l'interface dédiée se trouve ici : https://github.com/matthieu637/cpp-2a-info/issues (différent du pull request)
 
@@ -17,6 +21,9 @@ Pour reporter des bugs, l'interface dédiée se trouve ici : https://github.com/
 Pour les contributions à la documentation, il est inutile de modifier les fichiers du répertoire /docs.
 Ils sont générés à l'aide du script 2017/docgen et du fichier 2017/client.py.
 Il suffit donc de modifier les commentaires présents dans le fichier 2017/client.py, pour avoir un aperçu html de vos modifications vous pouvez appeler le script 2017/docgen (nécessite l'exécutable epydoc).
+
+Pour la documentation du serveur, vous pouvez utiliser SHIFT + ALT + J sur le nom d'une méthode dans eclipse.
+Contrairement à python, la documentation en java se place avant la fonction (exemple ici : https://github.com/matthieu637/SMA/blob/master/project/src/java/modele/percepts/Interpreteur.java)
 
 #### Serveur
 Pour les contributions au serveur, il est conseillé d'utiliser [l'IDE Eclipse](https://eclipse.org/downloads/) et d'[importer le projet SimBourse](http://stackoverflow.com/questions/6760115/importing-a-github-project-into-eclipse) pour lancer le serveur en local. Il faudra alors préciser au client de se connecter en localhost :
@@ -32,7 +39,7 @@ Puisque les nouvelles commandes que vous avez ajoutées ne seront pas directemen
 - [x] ~~[ajouter un code d'erreur pour un appel à fonction alors que la partie est finie (client)](https://github.com/matthieu637/cpp-2a-info/pull/1)~~ terminé par [david540](https://github.com/david540)
 - [ ] documenter le code java pour tenter de le comprendre : SHIFT + ALT + J sur le nom d'une méthode dans eclipse (serveur)
 - [ ] ajouter le type de l'ordre dans les tuples reçus par la fonction historique (serveur)
-- [ ] ajouter un argument pour limiter la taille des listes reçues dans historiques, achats et ventes pour diminuer la taille des messages réseaux (client+serveur)
+- [ ] ajouter un argument facultatif pour limiter la taille des listes reçues dans achats et ventes afin de diminuer la taille des messages réseaux (client+serveur)
 - [ ] ajouter un cache pour la fonction historique pour réduire la taille de la liste à passer au réseau (client+serveur) ([idée émise](https://github.com/matthieu637/cpp-2a-info/pull/1) par [david540](https://github.com/david540))
 
 Pour les contributions suivantes (les plus difficiles), il est inutile, pour le moment, d'implémenter uniquement ces fonctions dans le client (avec de multiples requêtes au serveur). L'intérêt étant qu'elles soient justement exécutées au plus vite du côté serveur avant les autres requêtes. Si elles ne sont pas terminées avant la compétition, chaque étudiant pourra alors décider de les implémenter du côté de son client (pas besoin de partager votre solution).

--- a/README.md
+++ b/README.md
@@ -1,4 +1,42 @@
 # cpp-2a-info
 CPP - Prépa des INP - Nancy | Projet Informatique 2ème année
 
-Documentation : https://matthieu637.github.io/cpp-2a-info/client.Reseau-class.html
+Documentation officielle : https://matthieu637.github.io/cpp-2a-info/client.Reseau-class.html
+
+[Documentation alternative (non vérifiée)](http://documentation-matthieu-devalle.readthedocs.io) par [MatthieuDEVALLE](https://github.com/matthieuDEVALLE)
+
+### Contributions
+Pour les plus motiver, nous vous encourageons à améliorer le projet (il vous faudra un compte sur github, utiliser [git](https://openclassrooms.com/courses/gerer-son-code-avec-git-et-github), [forker le projet et proposer des pull requests](https://help.github.com/articles/creating-a-pull-request-from-a-fork/)).
+
+Attention à garder vos [branches à jour](https://help.github.com/articles/syncing-a-fork/#platform-linux)
+avant de pull request au risque que nos branches master divergent (https://github.com/matthieu637/cpp-2a-info/network). Cela vous permettra également de résoudre les conflits avant tout pull request.
+
+Pour reporter des bugs, l'interface dédiée se trouve ici : https://github.com/matthieu637/cpp-2a-info/issues (différent du pull request)
+
+#### Documentation
+Pour les contributions à la documentation, il est inutile de modifier les fichiers du répertoire /docs.
+Ils sont générés à l'aide du script 2017/docgen et du fichier 2017/client.py.
+Il suffit donc de modifier les commentaires présents dans le fichier 2017/client.py, pour avoir un aperçu html de vos modifications vous pouvez appeler le script 2017/docgen (nécessite l'exécutable epydoc).
+
+#### Serveur
+Pour les contributions au serveur, il est conseillé d'utiliser [l'IDE Eclipse](https://eclipse.org/downloads/) et d'[importer le projet SimBourse](http://stackoverflow.com/questions/6760115/importing-a-github-project-into-eclipse) pour lancer le serveur en local. Il faudra alors préciser au client de se connecter en localhost :
+```
+r = Reseau('localhost', 23456) #au lieu de de r=Reseau()
+```
+Puisque les nouvelles commandes que vous avez ajoutées ne seront pas directement disponibles sur le serveur officiel, cela vous permettra d'effectuer des tests en local. Après la validation de votre pull request, le serveur officiel sera relancé avec les nouveaux changements, vous permettant alors de réutiliser r=Reseau().
+
+#### Contributions possibles (par difficulté)
+- [ ] [améliorer/correction](http://epydoc.sourceforge.net/manual-epytext.html) de la documentation (client.py)
+- [ ] expliquer de façon simple le classement dans la [documentation](http://epydoc.sourceforge.net/manual-epytext.html) (client.py) : information présente dans la fonction core.Joueur::compareTo(Joueur) 
+- [x] ~~[faire un cache pour la fonction fin avec un compteur local pour diminuer les requêtes serveurs (client.py)](https://github.com/matthieu637/cpp-2a-info/pull/1)~~ terminé par [david540](https://github.com/david540)
+- [x] ~~[ajouter un code d'erreur pour un appel à fonction alors que la partie est finie (client)](https://github.com/matthieu637/cpp-2a-info/pull/1)~~ terminé par [david540](https://github.com/david540)
+- [ ] documenter le code java pour tenter de le comprendre : SHIFT + ALT + J sur le nom d'une méthode dans eclipse (serveur)
+- [ ] ajouter le type de l'ordre dans les tuples reçus par la fonction historique (serveur)
+- [ ] ajouter un argument pour limiter la taille des listes reçues dans historiques, achats et ventes pour diminuer la taille des messages réseaux (client+serveur)
+- [ ] ajouter un cache pour la fonction historique pour réduire la taille de la liste à passer au réseau (client+serveur) ([idée émise](https://github.com/matthieu637/cpp-2a-info/pull/1) par [david540](https://github.com/david540))
+
+Pour les contributions suivantes (les plus difficiles), il est inutile, pour le moment, d'implémenter uniquement ces fonctions dans le client (avec de multiples requêtes au serveur). L'intérêt étant qu'elles soient justement exécutées au plus vite du côté serveur avant les autres requêtes. Si elles ne sont pas terminées avant la compétition, chaque étudiant pourra alors décider de les implémenter du côté de son client (pas besoin de partager votre solution).
+- [ ] ajouter des ordres "meilleurs prix" : écoule (achète/vend) x actions jusqu'à épuisement des x actions (client+serveur)
+- [ ] ajouter des [Stop orders](https://en.wikipedia.org/wiki/Order_(exchange)#Stop_orders) (client+serveur) : vend/achète x actions dès que le prix chute/augmente à y.
+
+[Liste des Contributeurs](https://github.com/matthieu637/cpp-2a-info/graphs/contributors)


### PR DESCRIPTION
Bonjour,
J'ai donc ajouté un historique côté client pour que le serveur n'envoie que l'historique manquant.
J'ai repéré quelque chose qui m'a étonné, je ne sais pas si c'est voulu:

>>> r.ask("Facebook",20,1)

38269864

>>> r.bid("Facebook",20,1)

0

>>> r.historiques("Facebook")

[('banque', 'dd', 25.0, 1.0), ('dd', 'dd', 20.0, 1.0)]

>>> r.bid("Facebook",20,1)

35759470

>>> r.ask("Facebook",20,1)

0

>>> r.historiques("Facebook")

[('banque', 'dd', 25.0, 1.0), ('dd', 'dd', 20.0, 1.0), ('dd', 'dd', 20.0, 0.0), ('dd', 'dd', 20.0, 1.0)]

(test effectué avec les codes initiaux, pas ceux que je viens de réécrire)
Le serveur envoie ('dd', 'dd', 20.0, 0.0), ('dd', 'dd', 20.0, 1.0) au lieu de simplement ('dd', 'dd', 20.0, 1.0)
Je pense qu'il suffit de faire un test côté serveur pour n'envoyer que si le 4eme paramètre est >0 mais peut être que le bug est plus grave que ça.
