### PR TITLE
Rend l'argument action insensible à la casse dans la fonction historique

### DIFF
--- a/2017/client.py
+++ b/2017/client.py
@@ -327,6 +327,8 @@ class Reseau:
 		@param action: le nom de l'action
 		@type action: string
 		'''
+		
+		action=action.replace(action[0],action[0].upper(),1) #On change (en majuscule) le premier caractère de la chaine
 		self.__estTop()
 		self.__notEnd()
 		self.__envoyer("HISTO "+action+" "+str(len(self.histoActions[action])))

--- a/2017/client.py
+++ b/2017/client.py
@@ -327,7 +327,7 @@ class Reseau:
 		@param action: le nom de l'action
 		@type action: string
 		'''
-		
+		action=action.lower()
 		action=action.replace(action[0],action[0].upper(),1) #On change (en majuscule) le premier caractère de la chaine
 		self.__estTop()
 		self.__notEnd()


### PR DESCRIPTION
Permet d'utiliser:

>>> r.historiques('google') 

sans erreur.

Cordialement,

