### PR TITLE
resolution petit bug dans le classement

### DIFF
--- a/2017/SimBourse/src/core/Marche.java
+++ b/2017/SimBourse/src/core/Marche.java
@@ -395,7 +395,7 @@ public class Marche {
 			secondes = 0;
 		sb.append(String.valueOf(secondes));
 		if (fini) {
-			sb.append(",'classement':[");
+			sb.append(",'classement':");
 			synchronized(this){
 				Collections.sort(liste_joueurs);
 			}


### PR DESCRIPTION
le r.fin() quand le temps est fini affiche {'temps':0,'classement':[['David']} et cause une erreur (double crochet ouvrant)
avec cette modif : {'temps':0,'classement':['David']}