### PR TITLE
Resolution de l'issue

### DIFF
--- a/2017/client.py
+++ b/2017/client.py
@@ -143,7 +143,8 @@ class Reseau:
 					if back == b'':
 						raise RuntimeError("Connexion perdu. _6")
 					result += back.decode()
-					break
+					if length == len(result):
+						break
 				
 			return result
 		except (ConnectionRefusedError):


### PR DESCRIPTION
L'issue, je pense, venait du fait que le message n'était pas tout le temps découpé tout les 4096 bytes, et donc le message n'était pas lu en entier