### PR TITLE
Résolution bug perte d'argent #29

### DIFF
--- a/2017/SimBourse/src/core/Marche.java
+++ b/2017/SimBourse/src/core/Marche.java
@@ -193,9 +193,11 @@ public class Marche {
 			return -5;
 		if (prix_achat <= 0.0)
 			return -6;
-		if((int)(volume_achat * prix_achat) == 0)
-			return -8;
 
+		volume_achat= (int)((int)(volume_achat*prix_achat)/prix_achat);
+		if(volume_achat==0)
+			return -8;
+		
 		mutex_ordre_write.lock();
 		int argent_joueur= joueur_achat.getSolde_euros();
 		int argent_engage = (int) (volume_achat * prix_achat);
@@ -271,7 +273,9 @@ public class Marche {
 			return -8;
 		if (prix_vente <= 0.0)
 			return -9;
-		if((int)(volume_vente * prix_vente) == 0)
+		
+		volume_vente= (int)((int)(volume_vente * prix_vente)/prix_vente);
+		if(volume_vente==0)
 			return -11;
 
 		mutex_ordre_write.lock();


### PR DESCRIPTION
Avant cette modif:
>>> r.ask("Facebook",0.01,250)
34002668
>>> r.bid("Facebook",0.01,250)
0
>>> r.solde()
{'Google': 1000, 'Apple': 1000, 'Facebook': 1000, 'Trydea': 1000, 'euros': 999}

Après cette modif:
>>> r.ask("Facebook",0.01,250)
98499487
>>> r.bid("Facebook",0.01,250)
0
>>> r.solde()
{'Facebook': 1000, 'Google': 1000, 'Apple': 1000, 'Trydea': 1000, 'euros': 1000}

ça résout les problèmes de pertes d'argent (ou d'actions), est ce que ça en cause d'autres ? #29